### PR TITLE
#28 feat 다이얼로그 커스텀

### DIFF
--- a/app/src/main/java/kr/co/lion/application/finalproject_aparttalk/ui/community/fragment/CommunityAddFragment.kt
+++ b/app/src/main/java/kr/co/lion/application/finalproject_aparttalk/ui/community/fragment/CommunityAddFragment.kt
@@ -16,6 +16,7 @@ import kr.co.lion.application.finalproject_aparttalk.R
 import kr.co.lion.application.finalproject_aparttalk.databinding.FragmentCommunityAddBinding
 import kr.co.lion.application.finalproject_aparttalk.databinding.RowCommunityAddImageBinding
 import kr.co.lion.application.finalproject_aparttalk.ui.community.adapter.CommunityAddImageViewPager2Adapter
+import kr.co.lion.application.finalproject_aparttalk.util.DialogConfirm
 
 class CommunityAddFragment(data: Bundle?) : Fragment() {
     lateinit var fragmentCommunityAddBinding: FragmentCommunityAddBinding
@@ -111,8 +112,12 @@ class CommunityAddFragment(data: Bundle?) : Fragment() {
             textViewCommunityAddContent.addTextChangedListener(textWatcher)
 
             buttonCommunityAdd.setOnClickListener {
-
-
+                val dialog = DialogConfirm(
+                    "게시글 등록 완료",
+                    "게시글 등록이 완료되었습니다.\n확인하러 가시겠습니까?",
+                    communityActivity
+                )
+                dialog.show(communityActivity.supportFragmentManager, "DialogConfirm")
             }
         }
     }

--- a/app/src/main/java/kr/co/lion/application/finalproject_aparttalk/ui/community/fragment/CommunityBottomSheetFragment.kt
+++ b/app/src/main/java/kr/co/lion/application/finalproject_aparttalk/ui/community/fragment/CommunityBottomSheetFragment.kt
@@ -5,14 +5,18 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.appcompat.app.AppCompatActivity
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import kr.co.lion.application.finalproject_aparttalk.util.DialogConfirmCancel
+import kr.co.lion.application.finalproject_aparttalk.util.DialogConfirmCancelInterface
 import kr.co.lion.application.finalproject_aparttalk.ui.community.activity.CommunityActivity
 import kr.co.lion.application.finalproject_aparttalk.databinding.FragmentCommunityBottomSheetBinding
 import kr.co.lion.application.finalproject_aparttalk.util.CommunityFragmentName
 
-class CommunityBottomSheetFragment(var communityDetailFragment: CommunityDetailFragment, communityIdx:Int) : BottomSheetDialogFragment() {
+class CommunityBottomSheetFragment(var communityDetailFragment: CommunityDetailFragment, communityIdx:Int) : BottomSheetDialogFragment(),
+    DialogConfirmCancelInterface {
     lateinit var fragmentCommunityBottomSheetBinding: FragmentCommunityBottomSheetBinding
     lateinit var communityActivity: CommunityActivity
 
@@ -39,7 +43,15 @@ class CommunityBottomSheetFragment(var communityDetailFragment: CommunityDetailF
 
             // 삭제
             buttonCommunityDetailDelete.setOnClickListener {
-
+                val dialog = DialogConfirmCancel(
+                    this@CommunityBottomSheetFragment,
+                    "게시글을 삭제하시겠습니까?",
+                    "한 번 삭제한 게시물은 복원할 수 없습니다.",
+                    communityActivity,
+                    0
+                )
+                dialog.show(communityActivity.supportFragmentManager, "DialogConfirmCancel")
+                dismiss()
             }
         }
     }
@@ -70,6 +82,14 @@ class CommunityBottomSheetFragment(var communityDetailFragment: CommunityDetailF
         layoutParams.height = ViewGroup.LayoutParams.WRAP_CONTENT
         bottomSheet.layoutParams = layoutParams
         behavior.state = BottomSheetBehavior.STATE_EXPANDED
+
+    }
+
+    override fun onConfirmButtonClick(id: Int) {
+        // 삭제 기능 넣을 것
+    }
+
+    override fun onConfirmButtonClick(activity: AppCompatActivity) {
 
     }
 

--- a/app/src/main/java/kr/co/lion/application/finalproject_aparttalk/ui/community/fragment/CommunityModifyFragment.kt
+++ b/app/src/main/java/kr/co/lion/application/finalproject_aparttalk/ui/community/fragment/CommunityModifyFragment.kt
@@ -17,6 +17,7 @@ import kr.co.lion.application.finalproject_aparttalk.databinding.FragmentCommuni
 import kr.co.lion.application.finalproject_aparttalk.databinding.RowCommunityModifyImageBinding
 import kr.co.lion.application.finalproject_aparttalk.ui.community.adapter.CommunityModifyImageViewPager2Adapter
 import kr.co.lion.application.finalproject_aparttalk.util.CommunityFragmentName
+import kr.co.lion.application.finalproject_aparttalk.util.DialogConfirm
 
 class CommunityModifyFragment(data: Bundle?) : Fragment() {
     lateinit var fragmentCommunityModifyBinding: FragmentCommunityModifyBinding
@@ -113,7 +114,12 @@ class CommunityModifyFragment(data: Bundle?) : Fragment() {
             textViewCommunityModifyContent.addTextChangedListener(textWatcher)
 
             buttonCommunityModify.setOnClickListener {
-
+                val dialog = DialogConfirm(
+                    "게시글 수정 완료",
+                    "게시글 수정이 완료되었습니다.\n확인하러 가시겠습니까?",
+                    communityActivity
+                )
+                dialog.show(communityActivity.supportFragmentManager, "DialogConfirm")
 
             }
         }

--- a/app/src/main/java/kr/co/lion/application/finalproject_aparttalk/util/DialogConfirm.kt
+++ b/app/src/main/java/kr/co/lion/application/finalproject_aparttalk/util/DialogConfirm.kt
@@ -1,0 +1,75 @@
+package kr.co.lion.application.finalproject_aparttalk.util
+
+import android.content.Context
+import android.graphics.Color
+import android.graphics.Point
+import android.graphics.drawable.ColorDrawable
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.view.WindowManager
+import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.DialogFragment
+import kr.co.lion.application.finalproject_aparttalk.databinding.DialogConfirmBinding
+
+class DialogConfirm(
+    subject: String?,
+    content: String,
+    activity: AppCompatActivity
+) : DialogFragment() {
+
+    lateinit var dialogConfirmBinding: DialogConfirmBinding
+
+    var subject = subject
+    var content = content
+    var activity = activity
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        dialogConfirmBinding = DialogConfirmBinding.inflate(layoutInflater)
+
+        // 레이아웃 배경을 투명하게
+        dialog?.window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
+
+        settingDialog()
+
+        return dialogConfirmBinding.root
+    }
+
+    override fun onResume() {
+        super.onResume()
+        val params: ViewGroup.LayoutParams? = dialog?.window?.attributes
+        val deviceWidth = gettingDeviceSize()
+        params?.width = (deviceWidth * 0.9).toInt()
+        dialog?.window?.attributes = params as WindowManager.LayoutParams
+    }
+
+    // 버튼 처리
+    private fun settingDialog() {
+        dialogConfirmBinding.apply {
+            // 다이얼로그 제목
+            textViewDialogConfirmSubject.text = subject
+
+            // 다이얼로그 내용
+            textViewDialogConfirmContent.text = content
+
+            // 확인 버튼
+            // 바텀 시트 닫기 / 게시글 등록 / 게시글 수정 등 처리 했다라는 걸 알려주는 용도로만 사용하는 것은 어떨까요?
+            buttonDialogConfirm.setOnClickListener {
+                dismiss()
+            }
+
+        }
+    }
+
+
+    // 디바이스 크기 구하기
+    private fun gettingDeviceSize() : Int {
+        val windowManager = activity.getSystemService(Context.WINDOW_SERVICE) as WindowManager
+        val display = windowManager.defaultDisplay
+        val size = Point()
+        display.getSize(size)
+
+        return size.x
+    }
+}

--- a/app/src/main/java/kr/co/lion/application/finalproject_aparttalk/util/DialogConfirmCancel.kt
+++ b/app/src/main/java/kr/co/lion/application/finalproject_aparttalk/util/DialogConfirmCancel.kt
@@ -1,0 +1,103 @@
+package kr.co.lion.application.finalproject_aparttalk.util
+
+import android.content.Context
+import android.graphics.Color
+import android.graphics.Point
+import android.graphics.drawable.ColorDrawable
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.view.WindowManager
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.isVisible
+import androidx.fragment.app.DialogFragment
+import kr.co.lion.application.finalproject_aparttalk.databinding.DialogConfirmCancelBinding
+
+class DialogConfirmCancel(
+    dialogConfirmCancelInterface: DialogConfirmCancelInterface,
+    subject: String?,
+    content: String,
+    activity: AppCompatActivity,
+    position: Int? = null, // 리사이클러뷰 삭제할 때 아이템 포지션
+    ) : DialogFragment() {
+
+    lateinit var dialogConfirmCancelBinding: DialogConfirmCancelBinding
+
+    var subject = subject
+    var content = content
+    var activity = activity
+    var dialogConfirmCancelInterface = dialogConfirmCancelInterface
+    var position = position
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        dialogConfirmCancelBinding = DialogConfirmCancelBinding.inflate(layoutInflater)
+
+        // 레이아웃 배경을 투명하게
+        dialog?.window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
+
+        settingDialog()
+
+        return dialogConfirmCancelBinding.root
+    }
+
+    override fun onResume() {
+        super.onResume()
+        val params: ViewGroup.LayoutParams? = dialog?.window?.attributes
+        val deviceWidth = gettingDeviceSize()
+        params?.width = (deviceWidth * 0.9).toInt()
+        dialog?.window?.attributes = params as WindowManager.LayoutParams
+    }
+
+    // 버튼 처리
+    private fun settingDialog() {
+        dialogConfirmCancelBinding.apply {
+
+            // 다이얼로그 제목
+            if (subject == null) {
+                textViewDialogConfirmCancelSubject.isVisible = false
+            } else {
+                textViewDialogConfirmCancelSubject.text = subject
+            }
+
+            // 다이얼로그 내용
+            textViewDialogConfirmCancelContent.text = content
+
+            // 확인 버튼
+            buttonDialogConfirmCancelConfirm.setOnClickListener {
+                if(position != null){
+                    // 삭제 확인 버튼
+                    dialogConfirmCancelInterface.onConfirmButtonClick(position!!)
+                    dismiss()
+                }else{
+                    // 그 외 확인 버튼
+                    dismiss()
+                    dialogConfirmCancelInterface.onConfirmButtonClick(activity)
+                }
+
+            }
+
+            // 취소 버튼
+            buttonDialogConfirmCancelCancel.setOnClickListener {
+                dismiss()
+            }
+        }
+    }
+
+
+    // 디바이스 크기 구하기
+    private fun gettingDeviceSize() : Int {
+        val windowManager = activity.getSystemService(Context.WINDOW_SERVICE) as WindowManager
+        val display = windowManager.defaultDisplay
+        val size = Point()
+        display.getSize(size)
+
+        return size.x
+    }
+}
+
+interface DialogConfirmCancelInterface {
+    fun onConfirmButtonClick(id: Int) // 삭제 확인 버튼
+
+    fun onConfirmButtonClick(activity: AppCompatActivity) // 그 외 확인 버튼
+}

--- a/app/src/main/res/drawable/dialog_round_white.xml
+++ b/app/src/main/res/drawable/dialog_round_white.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/white" />
+    <corners android:radius="10dp" />
+</shape>

--- a/app/src/main/res/layout/dialog_confirm.xml
+++ b/app/src/main/res/layout/dialog_confirm.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_marginHorizontal="20dp"
+    android:background="@drawable/dialog_round_white">
+
+    <TextView
+        android:id="@+id/textViewDialogConfirmSubject"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="25dp"
+        android:layout_marginTop="30dp"
+        android:layout_marginEnd="25dp"
+        android:fontFamily="@font/notosans_bold"
+        android:includeFontPadding="false"
+        android:gravity="center"
+        android:textAlignment="center"
+        android:textColor="@color/black"
+        android:textSize="18sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/textViewDialogConfirmContent"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="25dp"
+        android:layout_marginTop="10dp"
+        android:layout_marginEnd="25dp"
+        android:fontFamily="@font/notosans_semibold"
+        android:includeFontPadding="false"
+        android:gravity="center"
+        android:textAlignment="center"
+        android:textColor="@color/black"
+        android:textSize="14sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/textViewDialogConfirmSubject" />
+
+    <Button
+        android:id="@+id/buttonDialogConfirm"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="25dp"
+        android:layout_marginTop="20dp"
+        android:layout_marginEnd="25dp"
+        android:layout_marginBottom="20dp"
+        android:fontFamily="@font/notosans_bold"
+        android:includeFontPadding="false"
+        android:text="확인"
+        android:textSize="16sp"
+        android:backgroundTint="@color/third"
+        app:cornerRadius="10dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/textViewDialogConfirmContent" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/dialog_confirm_cancel.xml
+++ b/app/src/main/res/layout/dialog_confirm_cancel.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_marginHorizontal="20dp"
+    android:background="@drawable/dialog_round_white">
+
+    <TextView
+        android:id="@+id/textViewDialogConfirmCancelSubject"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="25dp"
+        android:layout_marginTop="30dp"
+        android:layout_marginEnd="25dp"
+        android:fontFamily="@font/notosans_bold"
+        android:includeFontPadding="false"
+        android:gravity="center"
+        android:textAlignment="center"
+        android:textColor="@color/black"
+        android:textSize="18sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/textViewDialogConfirmCancelContent"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="25dp"
+        android:layout_marginTop="30dp"
+        android:layout_marginEnd="25dp"
+        android:fontFamily="@font/notosans_semibold"
+        android:includeFontPadding="false"
+        android:gravity="center"
+        android:textAlignment="center"
+        android:textColor="@color/black"
+        android:textSize="14sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@+id/textViewDialogConfirmCancelSubject" />
+
+    <Button
+        android:id="@+id/buttonDialogConfirmCancelConfirm"
+        android:layout_width="150dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="20dp"
+        android:layout_marginEnd="25dp"
+        android:layout_marginBottom="20dp"
+        android:fontFamily="@font/notosans_bold"
+        android:includeFontPadding="false"
+        android:text="확인"
+        android:textSize="16sp"
+        android:backgroundTint="@color/third"
+        app:cornerRadius="10dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/textViewDialogConfirmCancelContent" />
+
+    <Button
+        android:id="@+id/buttonDialogConfirmCancelCancel"
+        style="@style/Widget.Material3.Button.OutlinedButton"
+        android:layout_width="150dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="25dp"
+        android:layout_marginTop="20dp"
+        android:layout_marginBottom="20dp"
+        android:fontFamily="@font/notosans_bold"
+        android:includeFontPadding="false"
+        android:text="취소"
+        android:textColor="@color/third"
+        android:textSize="16sp"
+        app:cornerRadius="10dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/textViewDialogConfirmCancelContent"
+        app:strokeColor="@color/third" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
DialogConfirmCancel.kt
DialogConfirm.kt
확인과 취소 버튼 있는 DialogConfirmCancel
확인 버튼만 있는 DialogConfirm

## #️⃣연관된 이슈

> #28 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
[DialogConfirm.webm](https://github.com/APP-Android2/FinalProject-ApartTalk/assets/137624438/00210c41-025f-4e44-a024-732fda1ed100)
[DialogConfirmCancel.webm](https://github.com/APP-Android2/FinalProject-ApartTalk/assets/137624438/726834f3-2cfe-43b4-bbd5-05363f5f679e)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 커스텀 다이얼로그 UI 어떤가요?
> 확인/취소 버튼이 있는 다이얼로그는 삭제할 때를 생각하고 만들었습니다.
> 확인 버튼만 있는 다이얼로그는 단순히 어떤 처리를 했다를 보여줄 때를 생각하고 만들었습니다.
