### PR TITLE
191 fix 주민투표 데이터관련 수정

### DIFF
--- a/app/src/main/java/kr/co/lion/application/finalproject_aparttalk/model/VoteResultModel.kt
+++ b/app/src/main/java/kr/co/lion/application/finalproject_aparttalk/model/VoteResultModel.kt
@@ -4,5 +4,12 @@ data class VoteResultModel(
     val electionName: String = "",
     val electionDate: String = "",
     val results: String = "",
-    val userVotes: Map<String, Boolean> = emptyMap()
+    val userVotes: Map<String, Boolean> = emptyMap(),
+    val title: String = "",
+    val checkBox1Text: String = "",
+    val checkBox2Text: String = "",
+    val checkBox3Text: String = "",
+    val checkBox1Desc: String = "",
+    val checkBox2Desc: String = "",
+    val checkBox3Desc: String = ""
 )

--- a/app/src/main/java/kr/co/lion/application/finalproject_aparttalk/repository/VoteRepository.kt
+++ b/app/src/main/java/kr/co/lion/application/finalproject_aparttalk/repository/VoteRepository.kt
@@ -1,32 +1,24 @@
 package kr.co.lion.application.finalproject_aparttalk.repository
 
+import android.util.Log
 import com.google.firebase.firestore.FirebaseFirestore
 import kotlinx.coroutines.tasks.await
 import kr.co.lion.application.finalproject_aparttalk.model.VoteResultModel
 
 class VoteRepository(private val firestore: FirebaseFirestore) {
 
-    suspend fun getVoteData(): VoteResultModel? {
+    suspend fun getVoteData(voteDocumentId: String): VoteResultModel? {
         return try {
-            val document = firestore.collection("votes").document("your_vote_document_id").get().await()
+            val document = firestore.collection("votes").document(voteDocumentId).get().await()
             document.toObject(VoteResultModel::class.java)
         } catch (e: Exception) {
             null
         }
     }
 
-    suspend fun getVoteItems(): List<VoteResultModel> {
+    suspend fun getUserVoteStatus(voteDocumentId: String, userIdx: String): Boolean {
         return try {
-            val snapshot = firestore.collection("voteResults").get().await()
-            snapshot.documents.mapNotNull { it.toObject(VoteResultModel::class.java) }
-        } catch (e: Exception) {
-            emptyList()
-        }
-    }
-
-    suspend fun getUserVoteStatus(userIdx: String): Boolean {
-        return try {
-            val document = firestore.collection("votes").document("your_vote_document_id").get().await()
+            val document = firestore.collection("votes").document(voteDocumentId).get().await()
             val voteData = document.toObject(VoteResultModel::class.java)
             voteData?.userVotes?.get(userIdx) ?: false
         } catch (e: Exception) {
@@ -34,9 +26,9 @@ class VoteRepository(private val firestore: FirebaseFirestore) {
         }
     }
 
-    suspend fun updateUserVoteStatus(userIdx: String, hasVoted: Boolean): Boolean {
+    suspend fun updateUserVoteStatus(voteDocumentId: String, userIdx: String, hasVoted: Boolean): Boolean {
         return try {
-            val documentRef = firestore.collection("votes").document("your_vote_document_id")
+            val documentRef = firestore.collection("votes").document(voteDocumentId)
             firestore.runTransaction { transaction ->
                 val snapshot = transaction.get(documentRef)
                 val voteData = snapshot.toObject(VoteResultModel::class.java)
@@ -44,18 +36,29 @@ class VoteRepository(private val firestore: FirebaseFirestore) {
                 userVotes[userIdx] = hasVoted
                 transaction.update(documentRef, "userVotes", userVotes)
             }.await()
+            Log.d("VoteRepository", "User vote status updated successfully for user: $userIdx")
             true
         } catch (e: Exception) {
+            Log.e("VoteRepository", "Error updating user vote status", e)
             false
         }
     }
 
-    suspend fun getVoteResult(documentId: String): VoteResultModel? {
+    suspend fun getVoteItems(): List<VoteResultModel> {
         return try {
-            val document = firestore.collection("voteResults").document(documentId).get().await()
-            document.toObject(VoteResultModel::class.java)
+            val snapshot = firestore.collection("votes").get().await()
+            snapshot.documents.mapNotNull { it.toObject(VoteResultModel::class.java) }
         } catch (e: Exception) {
-            null
+            emptyList()
+        }
+    }
+
+    suspend fun getPastVotes(): List<VoteResultModel> {
+        return try {
+            val snapshot = firestore.collection("voteResults").get().await()
+            snapshot.documents.mapNotNull { it.toObject(VoteResultModel::class.java) }
+        } catch (e: Exception) {
+            emptyList()
         }
     }
 }

--- a/app/src/main/java/kr/co/lion/application/finalproject_aparttalk/ui/inquiry/InquiringAdapter.kt
+++ b/app/src/main/java/kr/co/lion/application/finalproject_aparttalk/ui/inquiry/InquiringAdapter.kt
@@ -1,5 +1,7 @@
 package kr.co.lion.application.finalproject_aparttalk.ui.inquiry
 
+import android.app.AlertDialog
+import android.content.Context
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.core.content.ContextCompat
@@ -12,6 +14,7 @@ import java.util.*
 
 class InquiringAdapter(
     private var inquiries: List<InquiryModel>,
+    private val currentUserIdx: String, // 현재 유저의 Idx
     private val onItemClick: (InquiryModel) -> Unit
 ) : RecyclerView.Adapter<InquiringAdapter.InquiringViewHolder>() {
 
@@ -43,7 +46,11 @@ class InquiringAdapter(
             rowinquiringTextViewTime.text = timeFormat.format(date)
 
             root.setOnClickListener {
-                onItemClick(inquiry)
+                if (inquiry.inquiryPrivate && inquiry.userIdx != currentUserIdx) {
+                    showPrivateDocumentDialog(holder.itemView.context)
+                } else {
+                    onItemClick(inquiry)
+                }
             }
         }
     }
@@ -51,5 +58,13 @@ class InquiringAdapter(
     fun updateList(newInquiries: List<InquiryModel>) {
         inquiries = newInquiries
         notifyDataSetChanged()
+    }
+
+    private fun showPrivateDocumentDialog(context: Context) {
+        AlertDialog.Builder(context)
+            .setTitle("비공개 문서")
+            .setMessage("해당 문서는 비공개 문서입니다.")
+            .setPositiveButton("확인", null)
+            .show()
     }
 }

--- a/app/src/main/java/kr/co/lion/application/finalproject_aparttalk/ui/inquiry/InquiringFragment.kt
+++ b/app/src/main/java/kr/co/lion/application/finalproject_aparttalk/ui/inquiry/InquiringFragment.kt
@@ -33,12 +33,14 @@ class InquiringFragment : Fragment() {
     }
 
     private fun setupRecyclerView() {
-        adapter = InquiringAdapter(emptyList()) { inquiry ->
-            inquiryViewModel.setSelectedInquiryModel(inquiry)
-            (activity as InquiryActivity).replaceFragment(InquiryFragmentName.INQUIRY_FRAGMENT, false, true, null)
+        inquiryViewModel.userModel.value?.let { user ->
+            adapter = InquiringAdapter(emptyList(), user.idx.toString()) { inquiry ->
+                inquiryViewModel.setSelectedInquiryModel(inquiry)
+                (activity as InquiryActivity).replaceFragment(InquiryFragmentName.INQUIRY_FRAGMENT, false, true, null)
+            }
+            binding.inquiringRecyclerView.layoutManager = LinearLayoutManager(inquiryActivity)
+            binding.inquiringRecyclerView.adapter = adapter
         }
-        binding.inquiringRecyclerView.layoutManager = LinearLayoutManager(inquiryActivity)
-        binding.inquiringRecyclerView.adapter = adapter
     }
 
     private fun setupFloatingActionButton() {

--- a/app/src/main/java/kr/co/lion/application/finalproject_aparttalk/ui/vote/VoteFragment.kt
+++ b/app/src/main/java/kr/co/lion/application/finalproject_aparttalk/ui/vote/VoteFragment.kt
@@ -1,10 +1,11 @@
 package kr.co.lion.application.finalproject_aparttalk.ui.vote
 
 import android.os.Bundle
+import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.fragment.app.Fragment
+import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
 import com.google.firebase.auth.FirebaseAuth
@@ -34,8 +35,9 @@ class VoteFragment : Fragment() {
     // VoteRepository 초기화
     private val voteRepository by lazy { VoteRepository(firestore) }
 
+    // 실제 도큐먼트 ID를 전달하도록 수정
     private val voteViewModel: VoteViewModel by viewModels {
-        VoteViewModelFactory(voteRepository, userRepository)
+        VoteViewModelFactory(voteRepository, userRepository, "ltfkOHDzaur5lHbSxxDp")
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
@@ -74,13 +76,29 @@ class VoteFragment : Fragment() {
         binding.voteButton.setOnClickListener {
             val userIdx = firebaseAuth.currentUser?.uid
             if (userIdx != null) {
-                voteViewModel.updateUserVoteStatus(userIdx, true)
-                voteActivity.removeFragment(VoteFragmentName.VOTE_FRAGMENT)
-                voteActivity.replaceFragment(VoteFragmentName.VOTE_TAB_FRAGMENT, false, true, null)
+                voteViewModel.userVoteStatus.observe(viewLifecycleOwner, Observer { hasVoted ->
+                    if (hasVoted) {
+                        showAlreadyVotedDialog()
+                    } else {
+                        voteViewModel.updateUserVoteStatus(userIdx, true)
+                        voteActivity.removeFragment(VoteFragmentName.VOTE_FRAGMENT)
+                        voteActivity.replaceFragment(VoteFragmentName.VOTE_TAB_FRAGMENT, false, true, null)
+                    }
+                })
             } else {
                 // 사용자 ID를 가져오지 못한 경우 처리
             }
         }
+    }
+
+    private fun showAlreadyVotedDialog() {
+        val builder = AlertDialog.Builder(requireContext())
+        builder.setTitle("알림")
+        builder.setMessage("이미 투표하셨습니다.")
+        builder.setPositiveButton("확인") { dialog, _ ->
+            dialog.dismiss()
+        }
+        builder.show()
     }
 
     private fun setupCheckBoxes() {
@@ -143,6 +161,21 @@ class VoteFragment : Fragment() {
 
         voteViewModel.user.observe(viewLifecycleOwner, Observer { user ->
             // 사용자 정보를 사용하여 UI 업데이트 (필요한 경우)
+        })
+
+        voteViewModel.voteItems.observe(viewLifecycleOwner, Observer { voteItems ->
+            voteItems?.let { items ->
+                if (items.isNotEmpty()) {
+                    val item = items[0]
+                    binding.voteTextView.text = item.electionName
+                    binding.voteCheckBox1.text = item.checkBox1Text
+                    binding.voteCheckBox2.text = item.checkBox2Text
+                    binding.voteCheckBox3.text = item.checkBox3Text
+                    binding.voteTextView2.text = item.checkBox1Desc
+                    binding.voteTextView4.text = item.checkBox2Desc
+                    binding.voteTextView6.text = item.checkBox3Desc
+                }
+            }
         })
     }
 }

--- a/app/src/main/java/kr/co/lion/application/finalproject_aparttalk/ui/vote/VoteListAdapter.kt
+++ b/app/src/main/java/kr/co/lion/application/finalproject_aparttalk/ui/vote/VoteListAdapter.kt
@@ -9,7 +9,8 @@ import kr.co.lion.application.finalproject_aparttalk.util.VoteFragmentName
 
 class VoteListAdapter(
     private val voteActivity: VoteActivity,
-    private var voteItems: List<VoteResultModel>
+    private var voteItems: List<VoteResultModel>,
+    private var pastVoteItems: List<VoteResultModel>
 ) : RecyclerView.Adapter<VoteListAdapter.VoteListViewHolder>() {
 
     inner class VoteListViewHolder(val binding: RowVoteBinding) : RecyclerView.ViewHolder(binding.root)
@@ -20,12 +21,10 @@ class VoteListAdapter(
         return VoteListViewHolder(binding)
     }
 
-    override fun getItemCount(): Int {
-        return voteItems.size
-    }
+    override fun getItemCount(): Int = pastVoteItems.size
 
     override fun onBindViewHolder(holder: VoteListViewHolder, position: Int) {
-        val voteItem = voteItems[position]
+        val voteItem = pastVoteItems[position]
         holder.binding.rowVoteTextView1.text = voteItem.electionName
         holder.binding.rowVoteTextView2.text = voteItem.electionDate
 
@@ -34,8 +33,9 @@ class VoteListAdapter(
         }
     }
 
-    fun updateVoteItems(newVoteItems: List<VoteResultModel>) {
+    fun updateVoteItems(newVoteItems: List<VoteResultModel>, newPastVoteItems: List<VoteResultModel>) {
         voteItems = newVoteItems
+        pastVoteItems = newPastVoteItems
         notifyDataSetChanged()
     }
 }

--- a/app/src/main/java/kr/co/lion/application/finalproject_aparttalk/ui/vote/VoteListFragment.kt
+++ b/app/src/main/java/kr/co/lion/application/finalproject_aparttalk/ui/vote/VoteListFragment.kt
@@ -1,10 +1,11 @@
 package kr.co.lion.application.finalproject_aparttalk.ui.vote
 
 import android.os.Bundle
+import android.util.Log
+import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -34,8 +35,9 @@ class VoteListFragment : Fragment() {
     // VoteRepository 초기화
     private val voteRepository by lazy { VoteRepository(firestore) }
 
+    // 실제 도큐먼트 ID를 전달하도록 수정
     private val voteViewModel: VoteViewModel by viewModels {
-        VoteViewModelFactory(voteRepository, userRepository)
+        VoteViewModelFactory(voteRepository, userRepository, "your_vote_document_id")
     }
 
     private lateinit var voteListAdapter: VoteListAdapter
@@ -53,12 +55,34 @@ class VoteListFragment : Fragment() {
 
     private fun setupObservers() {
         voteViewModel.voteItems.observe(viewLifecycleOwner, Observer { voteItems ->
+            Log.d("VoteListFragment", "Vote items observed: $voteItems")
             voteItems?.let {
-                voteListAdapter.updateVoteItems(it)
+                if (it.isNotEmpty() && it[0].electionName.isNotEmpty()) {
+                    binding.voteListCardTextView.text = it[0].electionName
+                    binding.voteListCardTextView1.text = it[0].electionDate
+                    binding.voteListCardTextView.visibility = View.VISIBLE
+                    binding.voteListCardTextView1.visibility = View.VISIBLE
+                    binding.voteListButton.visibility = View.VISIBLE
+                    binding.noVoteTextView.visibility = View.GONE
+                } else {
+                    binding.voteListCardTextView.visibility = View.GONE
+                    binding.voteListCardTextView1.visibility = View.GONE
+                    binding.voteListButton.visibility = View.GONE
+                    binding.noVoteTextView.visibility = View.VISIBLE
+                }
+                voteListAdapter.updateVoteItems(it, voteViewModel.pastVotes.value ?: emptyList())
+            }
+        })
+
+        voteViewModel.pastVotes.observe(viewLifecycleOwner, Observer { pastVoteItems ->
+            Log.d("VoteListFragment", "Past votes observed: $pastVoteItems")
+            pastVoteItems?.let {
+                voteListAdapter.updateVoteItems(voteViewModel.voteItems.value ?: emptyList(), it)
             }
         })
 
         voteViewModel.hasOngoingVote.observe(viewLifecycleOwner, Observer { hasOngoingVote ->
+            Log.d("VoteListFragment", "Has ongoing vote observed: $hasOngoingVote")
             if (hasOngoingVote) {
                 binding.voteListCardTextView.visibility = View.VISIBLE
                 binding.voteListCardTextView1.visibility = View.VISIBLE
@@ -74,7 +98,7 @@ class VoteListFragment : Fragment() {
     }
 
     private fun setupRecyclerView() {
-        voteListAdapter = VoteListAdapter(voteActivity, emptyList())
+        voteListAdapter = VoteListAdapter(voteActivity, emptyList(), emptyList())
         binding.voteListRecyclerView.apply {
             adapter = voteListAdapter
             layoutManager = LinearLayoutManager(voteActivity)

--- a/app/src/main/java/kr/co/lion/application/finalproject_aparttalk/ui/vote/VoteViewModel.kt
+++ b/app/src/main/java/kr/co/lion/application/finalproject_aparttalk/ui/vote/VoteViewModel.kt
@@ -12,7 +12,8 @@ import kr.co.lion.application.finalproject_aparttalk.repository.VoteRepository
 
 class VoteViewModel(
     private val voteRepository: VoteRepository,
-    private val userRepository: UserRepository
+    private val userRepository: UserRepository,
+    private val voteDocumentId: String
 ) : ViewModel() {
 
     private val _userVoteStatus = MutableLiveData<Boolean>()
@@ -24,24 +25,29 @@ class VoteViewModel(
     private val _hasOngoingVote = MutableLiveData<Boolean>()
     val hasOngoingVote: LiveData<Boolean> get() = _hasOngoingVote
 
+    private val _pastVotes = MutableLiveData<List<VoteResultModel>>()
+    val pastVotes: LiveData<List<VoteResultModel>> get() = _pastVotes
+
     private val _user = MutableLiveData<UserModel?>()
     val user: LiveData<UserModel?> get() = _user
 
     init {
         fetchVoteItems()
+        fetchPastVotes()
         checkOngoingVote()
     }
 
-    fun getUserVoteStatus(userIdx: String) {
+    fun getUserVoteStatus(userIdx: String): LiveData<Boolean> {
         viewModelScope.launch {
-            val hasVoted = voteRepository.getUserVoteStatus(userIdx)
+            val hasVoted = voteRepository.getUserVoteStatus(voteDocumentId, userIdx)
             _userVoteStatus.postValue(hasVoted)
         }
+        return _userVoteStatus
     }
 
     fun updateUserVoteStatus(userIdx: String, hasVoted: Boolean) {
         viewModelScope.launch {
-            val success = voteRepository.updateUserVoteStatus(userIdx, hasVoted)
+            val success = voteRepository.updateUserVoteStatus(voteDocumentId, userIdx, hasVoted)
             if (success) {
                 _userVoteStatus.postValue(hasVoted)
             }
@@ -62,9 +68,16 @@ class VoteViewModel(
         }
     }
 
+    private fun fetchPastVotes() {
+        viewModelScope.launch {
+            val items = voteRepository.getPastVotes()
+            _pastVotes.postValue(items)
+        }
+    }
+
     private fun checkOngoingVote() {
         viewModelScope.launch {
-            val voteData = voteRepository.getVoteData()
+            val voteData = voteRepository.getVoteData(voteDocumentId)
             _hasOngoingVote.postValue(voteData != null && voteData.electionName.isNotEmpty())
         }
     }

--- a/app/src/main/java/kr/co/lion/application/finalproject_aparttalk/ui/vote/VoteViewModelFactory.kt
+++ b/app/src/main/java/kr/co/lion/application/finalproject_aparttalk/ui/vote/VoteViewModelFactory.kt
@@ -7,12 +7,13 @@ import kr.co.lion.application.finalproject_aparttalk.repository.VoteRepository
 
 class VoteViewModelFactory(
     private val voteRepository: VoteRepository,
-    private val userRepository: UserRepository
+    private val userRepository: UserRepository,
+    private val voteDocumentId: String
 ) : ViewModelProvider.Factory {
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
         if (modelClass.isAssignableFrom(VoteViewModel::class.java)) {
             @Suppress("UNCHECKED_CAST")
-            return VoteViewModel(voteRepository, userRepository) as T
+            return VoteViewModel(voteRepository, userRepository, voteDocumentId) as T
         }
         throw IllegalArgumentException("Unknown ViewModel class")
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

> 주민투표에 투표할 수 있는 항목 생성 및 중복투표 불가하도록 하고, 관리사무소 문의화면 자신이 작성한 비공개 글만 볼 수 있고 타인이 작성한 비공개 글은 볼 수 없도록 수정

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요
